### PR TITLE
[ART-1156] chore: update gradle 2.3.3 repo, jcenter and maven no longer available

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,10 @@
 buildscript {
   repositories {
-    jcenter()
-    maven { url "https://dl.bintray.com/android/android-tools" }
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
-  }
+		maven { url 'https://repository.axelor.com/nexus/repository/maven-public/' }
+	}
+	dependencies {
+		classpath 'com.android.tools.build:gradle:2.3.3'
+	}
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
**JIRA Ticket**
[ART-1156](https://goclick.atlassian.net/browse/ART-1156)

**Description of Changes**
Remove deprecated gradle repos and update with a new available one.